### PR TITLE
Feature/make users list

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -29,10 +29,11 @@ class UserController extends Controller
                       ->orWhere('self_sentence', 'like', '%' . $value . '%');
             }
         }
+        $users_count = $query->count();
         $query->value('id', 'name', 'icon_url');
 
         $users = $query->latest()->paginate(10);
 
-        return view('user.lists', compact('users', 'search', 'search_tag'));
+        return view('user.lists', compact('users', 'users_count', 'search', 'search_tag'));
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class UserController extends Controller
+{
+    public function list(Request $request)
+    {
+        $search = $request->input('search');
+        $search_tag = $request->input('tag_checkbox');
+
+        if (Auth::check()) {
+            $query = User::query()->where('id', '<>', Auth::id());
+        } else {
+            $query = User::query();
+        }
+
+        if ($search != NULL) {
+            // 単語を半角スペースで区切る
+            $space_search = mb_convert_kana($search, 's');
+            $search_words_array = preg_split('/[\s,]+/', $space_search, -1, PREG_SPLIT_NO_EMPTY);
+
+            foreach ($search_words_array as $value) {
+                $query->orWhere('name', 'like', '%' . $value . '%')
+                      ->orWhere('self_sentence', 'like', '%' . $value . '%');
+            }
+        }
+        $query->value('id', 'name', 'icon_url');
+
+        $users = $query->latest()->paginate(10);
+
+        return view('user.lists', compact('users', 'search', 'search_tag'));
+    }
+}

--- a/resources/views/user/lists.blade.php
+++ b/resources/views/user/lists.blade.php
@@ -42,7 +42,11 @@
 </form>
 <div class="row mb-3">
     <div class="col-2"></div>
-    <p class="col-8 text-left">&nbsp;全{{$users_count}}人</p>
+    <p class="col-8 text-left">
+        @if ($users_count != 0)
+        &nbsp;全{{$users_count}}人
+        @endif
+    </p>
     <div class="col-2"></div>
     <div class="col-2"></div>
         <div class="col-8 border">

--- a/resources/views/user/lists.blade.php
+++ b/resources/views/user/lists.blade.php
@@ -1,0 +1,82 @@
+@extends('layouts.app')
+@section('content')
+<h1 class="text-center mb-5">ユーザー一覧</h1>
+<form action="{{ route('user.list') }}" class="mb-3">
+    <div class="form-group row">
+        <div class="col-2"></div>
+        <label for="inputEmail3" class="col-2 col-form-label">
+            キーワード
+        </label>
+        <div class="col-6">
+          <input type="text" name="search"
+                 value="{{ $search }}"
+                 class="form-control"
+                 placeholder="">
+        </div>
+        <div class="col-2"></div>
+    </div>
+    <div class="form-group row">
+      <div class="col-2"></div>
+      <label for="inputPassword3" class="col-2 col-form-label">
+          タグで検索
+      </label>
+      <div class="col-6">
+          <div class="form-check form-check-inline">
+              <input name="tag_checkbox[]" type="checkbox" class="form-check-input" value="1"
+                  {{ is_array($search_tag) && in_array(1, $search_tag) ? 'checked' : '' ; }}>
+              <label class="form-check-label" for="tag_checkbox1">PHP</label>
+          </div>
+          <div class="form-check form-check-inline">
+              <input name="tag_checkbox[]" type="checkbox" class="form-check-input" value="2"
+                  {{ is_array($search_tag) && in_array(2, $search_tag) ? 'checked' : '' ; }}>
+              <label class="form-check-label" for="tag_checkbox2">JavaScript</label>
+          </div>
+      </div>
+      <div class="col-2"></div>
+    </div>
+        <div class="text-center">
+            <button type="submit" id="btn-search" class="btn btn-primary">
+                <i class="fas fa-search"></i>キーワードで絞り込む
+            </button>
+        </div>
+    </div>
+</form>
+<div class="row mb-3">
+    <div class="col-2"></div>
+        <div class="col-8 border">
+            @if ($users->isNotEmpty())
+            <table class="table">
+                <tbody>
+                @foreach ($users as $user)
+                <tr class="row">
+                    <td class="col-3">
+                        @if ($user->icon_url != Null)
+                            <img class="w-100 ml-3"
+                                 src="{{asset('/storage/images/'.$user->icon_url)}}">
+                        @else
+                            <img class="w-100 ml-3"
+                                 src="{{asset('/storage/images/nico.jpg')}}">
+                        @endif
+                    </td>
+                    <td class="col-9">
+                        <a href="/users/{{$user->id}}">
+                            <p class="text-left">
+                                {{$user->name}}<br>
+                                {{-- フェーズ２のタグ出力 --}}
+                            </p>
+                        </a>
+                    </td>
+                </tr>
+                @endforeach
+                </tbody>
+            </table>
+            @else
+        <p class="mt-3">動画が見つかりませんでした。</p>
+        @endif
+        </div>
+    <div class="col-2"></div>
+</div>
+<div class="d-flex justify-content-center mt-5 mb-5">
+    {!! $users->appends(['search'=>$search])->render() !!}
+</div>
+@endsection

--- a/resources/views/user/lists.blade.php
+++ b/resources/views/user/lists.blade.php
@@ -16,36 +16,38 @@
         <div class="col-2"></div>
     </div>
     <div class="form-group row">
-      <div class="col-2"></div>
-      <label for="inputPassword3" class="col-2 col-form-label">
-          タグで検索
-      </label>
-      <div class="col-6">
-          <div class="form-check form-check-inline">
-              <input name="tag_checkbox[]" type="checkbox" class="form-check-input" value="1"
-                  {{ is_array($search_tag) && in_array(1, $search_tag) ? 'checked' : '' ; }}>
-              <label class="form-check-label" for="tag_checkbox1">PHP</label>
-          </div>
-          <div class="form-check form-check-inline">
-              <input name="tag_checkbox[]" type="checkbox" class="form-check-input" value="2"
-                  {{ is_array($search_tag) && in_array(2, $search_tag) ? 'checked' : '' ; }}>
-              <label class="form-check-label" for="tag_checkbox2">JavaScript</label>
-          </div>
-      </div>
-      <div class="col-2"></div>
+        <div class="col-2"></div>
+        <label for="inputPassword3" class="col-2 col-form-label">
+            タグで検索
+        </label>
+        <div class="col-6">
+            <div class="form-check form-check-inline">
+                <input name="tag_checkbox[]" type="checkbox" class="form-check-input" value="1"
+                    {{ is_array($search_tag) && in_array(1, $search_tag) ? 'checked' : '' ; }}>
+                <label class="form-check-label" for="tag_checkbox1">PHP</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input name="tag_checkbox[]" type="checkbox" class="form-check-input" value="2"
+                    {{ is_array($search_tag) && in_array(2, $search_tag) ? 'checked' : '' ; }}>
+                <label class="form-check-label" for="tag_checkbox2">JavaScript</label>
+            </div>
+        </div>
+        <div class="col-2"></div>
     </div>
     <div class="text-center">
         <button type="submit" id="btn-search" class="btn btn-primary">
-            <i class="fas fa-search"></i>キーワードで絞り込む
+            <i class="fas fa-search"></i>&nbsp;検索する
         </button>
     </div>
 </form>
 <div class="row mb-3">
     <div class="col-2"></div>
+    <p class="col-8 text-left">&nbsp;全{{$users_count}}人</p>
+    <div class="col-2"></div>
+    <div class="col-2"></div>
         <div class="col-8 border">
             @if ($users->isNotEmpty())
-            <table class="table">
-                <tbody>
+            <table class="table ">
                 @foreach ($users as $user)
                 <tr class="row">
                     <td class="col-3">
@@ -67,7 +69,6 @@
                     </td>
                 </tr>
                 @endforeach
-                </tbody>
             </table>
             @else
             <p class="mt-3">ユーザーが見つかりませんでした。</p>

--- a/resources/views/user/lists.blade.php
+++ b/resources/views/user/lists.blade.php
@@ -34,11 +34,10 @@
       </div>
       <div class="col-2"></div>
     </div>
-        <div class="text-center">
-            <button type="submit" id="btn-search" class="btn btn-primary">
-                <i class="fas fa-search"></i>キーワードで絞り込む
-            </button>
-        </div>
+    <div class="text-center">
+        <button type="submit" id="btn-search" class="btn btn-primary">
+            <i class="fas fa-search"></i>キーワードで絞り込む
+        </button>
     </div>
 </form>
 <div class="row mb-3">
@@ -71,8 +70,8 @@
                 </tbody>
             </table>
             @else
-        <p class="mt-3">ユーザーが見つかりませんでした。</p>
-        @endif
+            <p class="mt-3">ユーザーが見つかりませんでした。</p>
+            @endif
         </div>
     <div class="col-2"></div>
 </div>

--- a/resources/views/user/lists.blade.php
+++ b/resources/views/user/lists.blade.php
@@ -71,7 +71,7 @@
                 </tbody>
             </table>
             @else
-        <p class="mt-3">動画が見つかりませんでした。</p>
+        <p class="mt-3">ユーザーが見つかりませんでした。</p>
         @endif
         </div>
     <div class="col-2"></div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,4 +26,6 @@ Route::get('login/new','Auth\LoginController@showLoginForm')->name('loginnew');
 Route::get('login/new/{pw}','Auth\DetailController@showDetailForm')->name('detail');
 Route::post('login/new/{pw}','Auth\DetailController@signup')->name('signup.post');
 
+Route::get('users', 'UserController@list')->name('user.list');
+
 Route::get('movie', 'MovieController@index')->name('movie.index');


### PR DESCRIPTION
## 実装内容
【ユーザ一覧機能の実装】
・キーワードによる部分一致検索

## 再現手順
1.usersにアクセス
2.キーワードにユーザ名もしくは自己紹介文を入力し、検索
　
## 注意点
・タグで検索が出ておりますが、タグはフェーズ２以降なので検索機能は実装していないです
・シーダーファイルのURL情報ではエラーになります
・もしpubliにシンボリックリンクを作成していない場合は、コマンド「php artisan storage:link」で作成してください

一覧画面トップ
![ユーザ一覧画面](https://user-images.githubusercontent.com/57437984/198683066-78c424d2-68a9-457d-8ce9-f6769b98ad86.png)

検索した場合
![検索結果](https://user-images.githubusercontent.com/57437984/198683072-bb1018cb-a058-4bd3-a000-7bf4f9a00872.png)

検索結果がない場合
![検索結果ーなし](https://user-images.githubusercontent.com/57437984/198683078-7bad72f7-6161-4d7b-bc1e-dcc644b0ad6e.png)
