### PR TITLE
権限変更ページの登録

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -8,13 +8,18 @@ use Illuminate\Support\Facades\Auth;
 
 class UserController extends Controller
 {
+    public const FLAG_ON  = true;
+    public const FLAG_OFF = false;
+
     public function list(Request $request)
     {
         $search = $request->input('search');
         $search_tag = $request->input('tag_checkbox');
 
         if (Auth::check()) {
-            $query = User::query()->where('id', '<>', Auth::id());
+            // orで検索しているため、ログインユーザ以外が表示されるため除外
+            // $query = User::query()->where('id', '<>', Auth::id());
+            $query = User::query();
         } else {
             $query = User::query();
         }
@@ -35,5 +40,58 @@ class UserController extends Controller
         $users = $query->latest()->paginate(10);
 
         return view('user.lists', compact('users', 'users_count', 'search', 'search_tag'));
+    }
+
+    public function chengeAdministerList(Request $request)
+    {
+        $search = $request->input('search');
+
+        if (Auth::check()) {
+            // $query = User::query()->where('id', '<>', Auth::id());
+            $query = User::query();
+        } else {
+            $query = User::query();
+        }
+
+        if ($search != NULL) {
+            // 単語を半角スペースで区切る
+            $space_search = mb_convert_kana($search, 's');
+            $search_words_array = preg_split('/[\s,]+/', $space_search, -1, PREG_SPLIT_NO_EMPTY);
+
+            foreach ($search_words_array as $value) {
+                $query->orWhere('name', 'like', '%' . $value . '%');
+            }
+        }
+        $users_count = $query->count();
+        $query->value('id', 'name', 'icon_url', 'administrator_flag');
+
+        $users = $query->latest()->paginate(10);
+
+        return view('user.chengeAdministers', compact('users', 'search'));
+    }
+
+    public function chengeAdminister($id)
+    {
+        if (!isset($id)) {
+            return redirect()->route('user.chengeAdministerList');
+        }
+
+        try {
+            $query = User::where('id', $id)->first();
+
+            if ($query->administrator_flag) {
+                $update_administrator_flag = self::FLAG_OFF;
+
+            } else {
+                $update_administrator_flag = self::FLAG_ON;
+            }
+
+            User::where('id', $id)
+                  ->update(['administrator_flag'=>$update_administrator_flag]);
+
+        } catch(\Exception $e) {
+            logger()->error("chenge administer error".$e->getMessage());
+        }
+        return redirect()->route('user.chengeAdministerList');
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -81,7 +81,6 @@ class UserController extends Controller
 
             if ($query->administrator_flag) {
                 $update_administrator_flag = self::FLAG_OFF;
-
             } else {
                 $update_administrator_flag = self::FLAG_ON;
             }
@@ -89,7 +88,7 @@ class UserController extends Controller
             User::where('id', $id)
                   ->update(['administrator_flag'=>$update_administrator_flag]);
 
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             logger()->error("chenge administer error".$e->getMessage());
         }
         return redirect()->route('user.chengeAdministerList');

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -14,6 +14,9 @@
                         </a>
                     </li> -->
                     <li>
+                        <a class="nav-item nav-link" href="{{ route('user.list') }}">ユーザ一覧</a>
+                    </li>
+                    <li>
                         <a class="nav-item nav-link" href="{{ route('movie.index') }}">動画一覧</a>
                     </li>
                     <li class="nav-item">

--- a/resources/views/user/chengeAdministers.blade.php
+++ b/resources/views/user/chengeAdministers.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+@section('content')
+<h1 class="text-center mb-5">ユーザー一覧</h1>
+<form action="{{ route('user.chengeAdministerList') }}" class="mb-3">
+    <div class="form-group row">
+        <div class="col-2"></div>
+        <label for="inputEmail3" class="col-2 col-form-label">
+            ユーザー名
+        </label>
+        <div class="col-6">
+          <input type="text" name="search"
+                 value="{{ $search }}"
+                 class="form-control"
+                 placeholder="">
+        </div>
+        <div class="col-2"></div>
+    </div>
+    <div class="text-center">
+        <button type="submit" id="btn-search" class="btn btn-primary">
+            <i class="fas fa-search"></i>&nbsp;検索する
+        </button>
+    </div>
+</form>
+<div class="row mb-3">
+    <div class="col-2"></div>
+        <div class="col-8 border">
+            @if ($users->isNotEmpty())
+            <table class="table ">
+                <tr class="row">
+                    <td class="col-3"></td>
+                    <td class="col-4 d-flex align-items-center text-left">
+                        <p>ユーザ情報</p>
+                    </td>
+                    <td class="col-5 d-flex align-items-center text-left">
+                        <p>管理者フラグ</p>
+                    </td>
+                </tr>
+                @foreach ($users as $user)
+                <tr class="row">
+                    <td class="col-3">
+                        @if ($user->icon_url != Null)
+                            <img class="w-100 ml-3"
+                                 src="{{asset('/storage/images/'.$user->icon_url)}}">
+                        @else
+                            <img class="w-100 ml-3"
+                                 src="{{asset('/storage/images/nico.jpg')}}">
+                        @endif
+                    </td>
+                    <td class="col-4 d-flex align-items-center text-left">
+                        <a href="/users/{{$user->id}}">
+                            <p>
+                                {{$user->name}}<br>
+                                {{-- フェーズ２のタグ出力 --}}
+                            </p>
+                        </a>
+                    </td>
+                    <td class="col-5 d-flex align-items-center text-left">
+                        <a href="/administer/users/{{$user->id}}">
+                            <p>
+                                @if ($user->administrator_flag)
+                                    一般に変更する。
+                                @else
+                                    管理者に変更する。
+                                @endif
+                            </p>
+                        </a>
+                    </td>
+                </tr>
+                @endforeach
+            </table>
+            @else
+            <p class="mt-3">ユーザーが見つかりませんでした。</p>
+            @endif
+        </div>
+    <div class="col-2"></div>
+</div>
+<div class="d-flex justify-content-center mt-5 mb-5">
+    {!! $users->appends(['search'=>$search])->render() !!}
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ Route::get('login/new/{pw}','Auth\DetailController@showDetailForm')->name('detai
 Route::post('login/new/{pw}','Auth\DetailController@signup')->name('signup.post');
 
 Route::get('users', 'UserController@list')->name('user.list');
+Route::get('administer/users', 'UserController@chengeAdministerList')->name('user.chengeAdministerList');
+Route::get('administer/users/{id}','UserController@chengeAdminister')->name('user.chengeAdminister');
 
 Route::get('movie', 'MovieController@index')->name('movie.index');
 Route::get('movie/{id}', 'MovieController@detail')->where('id', '[0-9]+')->name('movie.detail');

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,7 @@ Route::post('login/new/{pw}','Auth\DetailController@signup')->name('signup.post'
 
 Route::get('users', 'UserController@list')->name('user.list');
 Route::get('administer/users', 'UserController@chengeAdministerList')->name('user.chengeAdministerList');
-Route::get('administer/users/{id}','UserController@chengeAdminister')->name('user.chengeAdminister');
+Route::get('administer/users/{id}', 'UserController@chengeAdminister')->name('user.chengeAdminister');
 
 Route::get('movie', 'MovieController@index')->name('movie.index');
 Route::get('movie/{id}', 'MovieController@detail')->where('id', '[0-9]+')->name('movie.detail');


### PR DESCRIPTION
## 実装内容
【ユーザー権限変更機能の実装】
・名前を検索する。
・「一般に変更する」または「管理者に変更する」をクリックで権限を変更する

## 再現手順
1.administer/usersにアクセス
2.キーワードにユーザ名もしくは自己紹介文を入力し、検索
3.管理者フラグ列の任意の文字列をクリックする

権限変更画面トップ
![ユーザ権限一覧画面](https://user-images.githubusercontent.com/57437984/200176033-82f198f1-02f7-4ec0-a520-8c311cccae8d.png)
